### PR TITLE
fixed action args to reflect current api

### DIFF
--- a/app/markdown/testing.md
+++ b/app/markdown/testing.md
@@ -212,7 +212,7 @@ describe('nameChanged', function () {
     };
 
     // return the promise and mocha will wait for it to resolve
-    return testSignal(controller, controller.signals.nameChanged, signalInput, () => {
+    return testSignal(controller, controller.getSignals().nameChanged, signalInput, () => {
       expect(this.tree.get(['user', 'name'])).to.equal('Christian');
     });
   });

--- a/app/markdown/testing.md
+++ b/app/markdown/testing.md
@@ -10,7 +10,7 @@ All cerebral actions have the following signature:
 
 ```javascript
 
-function actionName (input, state, output, services) {
+function actionName ({input, state, output, services}) {
 
 }
 ```
@@ -23,7 +23,7 @@ Lets create an action called `toggleIsLoading` and then we can test it.
 
 ```javascript
 
-export default function toggleIsLoading(input, state) {
+export default function toggleIsLoading({input, state}) {
   state.set('isLoading', input.value);
 }
 ```
@@ -61,7 +61,7 @@ describe('toggleIsLoading()', function () {
     };
 
     // call the action
-    toggleIsLoading(input, state);
+    toggleIsLoading({input, state});
   });
 
 });
@@ -101,7 +101,7 @@ describe('someAsyncAction()', function () {
     };
 
     // call the async action
-    someAsyncAction(input, state, output);
+    someAsyncAction({input, state, output});
   });
 
 });


### PR DESCRIPTION
I also think we can make testing a bit simpler.. Maybe for testing signals even have a little helper lib from npm? Also it seems like there should be an easier way to set-up and tear-down the cerebral state tree... Just a thought
