### PR TITLE
Fix typo in HTTP module example

### DIFF
--- a/app/markdown/module_http.md
+++ b/app/markdown/module_http.md
@@ -18,7 +18,7 @@ controller.addModules({
   // Can pass any default options which
   // will be used on all requests
   http: Http({
-    baseUrl: '/api'
+    baseURL: '/api'
   })
 })
 ```


### PR DESCRIPTION
Axios uses `baseURL` not `baseUrl`

https://github.com/mzabriskie/axios#request-config
